### PR TITLE
Fix NPE in the android BlinkUpPlugin

### DIFF
--- a/src/android/BlinkUpPlugin.java
+++ b/src/android/BlinkUpPlugin.java
@@ -230,7 +230,7 @@ public class BlinkUpPlugin extends CordovaPlugin {
             planId = PreferencesHelper.getPlanId(activity);
         }
 
-        if(planId != null || !planId.isEmpty()) {
+        if(planId != null && !planId.isEmpty()) {
             controller.setPlanID(planId);
         }
 


### PR DESCRIPTION
[Description]
This patch takes care of fixing a possible NPE in the BlinkUpPlugin.java class for android.

[Changes]

```
-> src/android/BlinkUpPlugin.java :
    . We don't want to check emptieness if it's null.
```
